### PR TITLE
Add Fuel Rail Pressure Command

### DIFF
--- a/SUPPORTED_COMMANDS.md
+++ b/SUPPORTED_COMMANDS.md
@@ -47,7 +47,8 @@ Full list of supported commands.
 | `11` | `THROTTLE_POSITION` | Throttle Position |
 | `1F` | `ENGINE_RUNTIME` | Engine Runtime |
 | `21` | `DISTANCE_TRAVELED_MIL_ON` | Distance traveled with MIL on |
-| `23` | `FUEL_RAIL_PRESSURE` | Fuel Rail Pressure |
+| `22` | `FUEL_RAIL_PRESSURE` | Fuel Rail Pressure |
+| `23` | `FUEL_RAIL_GAUGE_PRESSURE` | Fuel Rail Gauge Pressure |
 | `2C` | `COMMANDED_EGR` | Commanded EGR |
 | `2F` | `FUEL_LEVEL` | Fuel Level |
 | `31` | `DISTANCE_TRAVELED_AFTER_CODES_CLEARED` | Distance traveled since codes cleared |

--- a/src/main/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
@@ -39,6 +39,16 @@ class FuelRailPressureCommand : ObdCommand() {
     override val tag = "FUEL_RAIL_PRESSURE"
     override val name = "Fuel Rail Pressure"
     override val mode = "01"
+    override val pid = "22"
+
+    override val defaultUnit = "kPa"
+    override val handler = { it: ObdRawResponse -> "%.3f".format(bytesToInt(it.bufferedValue) * 0.079) }
+}
+
+class FuelRailGaugePressureCommand : ObdCommand() {
+    override val tag = "FUEL_RAIL_GAUGE_PRESSURE"
+    override val name = "Fuel Rail Gauge Pressure"
+    override val mode = "01"
     override val pid = "23"
 
     override val defaultUnit = "kPa"

--- a/src/test/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
@@ -59,7 +59,6 @@ class IntakeManifoldPressureCommandParameterizedTests(private val rawValue: Stri
     }
 }
 
-
 @RunWith(Parameterized::class)
 class FuelPressureCommandParameterizedTests(private val rawValue: String, private val expected: Int) {
     companion object {
@@ -85,9 +84,32 @@ class FuelPressureCommandParameterizedTests(private val rawValue: String, privat
     }
 }
 
+@RunWith(Parameterized::class)
+class FuelRailPressureCommandParameterizedTests(private val rawValue: String, private val expected: Float) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun values() = listOf(
+            arrayOf("41230000", 0.000f),
+            arrayOf("410B39", 4.503f),
+            arrayOf("410B6464", 2030.300f),
+            arrayOf("4123FFFF", 5177.265f)
+        )
+    }
+
+    @Test
+    fun `test valid fuel rail pressure responses handler`() {
+        val rawResponse = ObdRawResponse(value = rawValue, elapsedTime = 0)
+        val obdResponse = FuelRailPressureCommand().run {
+            handleResponse(rawResponse)
+        }
+
+        assertEquals("%.3f".format(expected) + "kPa", obdResponse.formattedValue)
+    }
+}
 
 @RunWith(Parameterized::class)
-class FuelRailPressureCommandParameterizedTests(private val rawValue: String, private val expected: Int) {
+class FuelRailGaugePressureCommandParameterizedTests(private val rawValue: String, private val expected: Int) {
     companion object {
         @JvmStatic
         @Parameterized.Parameters
@@ -102,9 +124,9 @@ class FuelRailPressureCommandParameterizedTests(private val rawValue: String, pr
     }
 
     @Test
-    fun `test valid fuel rail pressure responses handler`() {
+    fun `test valid fuel rail gauge pressure responses handler`() {
         val rawResponse = ObdRawResponse(value = rawValue, elapsedTime = 0)
-        val obdResponse = FuelRailPressureCommand().run {
+        val obdResponse = FuelRailGaugePressureCommand().run {
             handleResponse(rawResponse)
         }
         assertEquals("${expected}kPa", obdResponse.formattedValue)


### PR DESCRIPTION
Relative to #8

In fact, there was already a Fuel Rail Pressure Command which was the Fuel Rail Gauge Pressure Command. I renamed it and add the new one. WDYT?