### PR TITLE
InputStream concurrency issue - Reduction to exceptions

### DIFF
--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -6,6 +6,7 @@ import com.github.eltonvs.obd.command.ObdResponse
 import com.github.eltonvs.obd.command.RegexPatterns.SEARCHING_PATTERN
 import com.github.eltonvs.obd.command.removeAll
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.io.OutputStream
@@ -16,12 +17,11 @@ import kotlin.system.measureTimeMillis
 class ObdDeviceConnection(private val inputStream: InputStream, private val outputStream: OutputStream) {
     private val responseCache = mutableMapOf<ObdCommand, ObdRawResponse>()
 
-    @Synchronized
     suspend fun run(
         command: ObdCommand,
         useCache: Boolean = false,
         delayTime: Long = 0
-    ): ObdResponse = withContext(Dispatchers.IO) {
+    ): ObdResponse = runBlocking {
         val obdRawResponse =
             if (useCache && responseCache[command] != null) {
                 responseCache.getValue(command)
@@ -36,7 +36,7 @@ class ObdDeviceConnection(private val inputStream: InputStream, private val outp
         command.handleResponse(obdRawResponse)
     }
 
-    private fun runCommand(command: ObdCommand, delayTime: Long): ObdRawResponse {
+    private suspend fun runCommand(command: ObdCommand, delayTime: Long): ObdRawResponse {
         var rawData = ""
         val elapsedTime = measureTimeMillis {
             sendCommand(command, delayTime)
@@ -45,32 +45,37 @@ class ObdDeviceConnection(private val inputStream: InputStream, private val outp
         return ObdRawResponse(rawData, elapsedTime)
     }
 
-    private fun sendCommand(command: ObdCommand, delayTime: Long = 0) {
-        outputStream.write("${command.rawCommand}\r".toByteArray())
-        outputStream.flush()
-        if (delayTime > 0) {
-            sleep(delayTime)
+    private suspend fun sendCommand(command: ObdCommand, delayTime: Long = 0) = runBlocking {
+        withContext(Dispatchers.IO) {
+            outputStream.write("${command.rawCommand}\r".toByteArray())
+            outputStream.flush()
+            if (delayTime > 0) {
+                sleep(delayTime)
+            }
         }
     }
 
-    private fun readRawData(): String {
+    private suspend fun readRawData(): String = runBlocking {
         var b: Byte
         var c: Char
         val res = StringBuffer()
 
-        // read until '>' arrives OR end of stream reached (-1)
-        while (inputStream.available() > 0) {
-            b = inputStream.read().toByte()
-            if (b < 0) {
-                break
+        withContext(Dispatchers.IO) {
+            // read until '>' arrives OR end of stream reached (-1)
+            while (inputStream.available() > 0) {
+                //println("InputStream Available: ${inputStream.available()}")
+                b = inputStream.read().toByte()
+                if (b < 0) {
+                    break
+                }
+                c = b.toChar()
+                if (c == '>') {
+                    break
+                }
+                res.append(c)
             }
-            c = b.toChar()
-            if (c == '>') {
-                break
-            }
-            res.append(c)
-        }
 
-        return removeAll(SEARCHING_PATTERN, res.toString()).trim()
+            removeAll(SEARCHING_PATTERN, res.toString()).trim()
+        }
     }
 }

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -63,7 +63,6 @@ class ObdDeviceConnection(private val inputStream: InputStream, private val outp
         withContext(Dispatchers.IO) {
             // read until '>' arrives OR end of stream reached (-1)
             while (inputStream.available() > 0) {
-                //println("InputStream Available: ${inputStream.available()}")
                 b = inputStream.read().toByte()
                 if (b < 0) {
                     break

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -67,7 +67,7 @@ class ObdDeviceConnection(private val inputStream: InputStream, private val outp
                 if (b < 0) {
                     break
                 }
-                c = b.toChar()
+                c = b.toInt().toChar()
                 if (c == '>') {
                     break
                 }


### PR DESCRIPTION
- Reducing number of exceptions that occur when attempting to request multiple commands from the OBD by blocking the calls to send command and waiting for response.

I am submitting this as a potential reduction to the number of exceptions occurring when trying to issue commands, similar to the issues raised in #14 and #7