### PR TITLE
Fix parsing for commands using first byte only

### DIFF
--- a/src/main/kotlin/com/github/eltonvs/obd/command/ParserFunctions.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/ParserFunctions.kt
@@ -13,7 +13,8 @@ fun bytesToInt(bufferedValue: IntArray, start: Int = 2, bytesToProcess: Int = -1
     }
 }
 
-fun calculatePercentage(bufferedValue: IntArray): Float = (bytesToInt(bufferedValue) * 100f) / 255f
+fun calculatePercentage(bufferedValue: IntArray, bytesToProcess: Int = -1): Float =
+    (bytesToInt(bufferedValue, bytesToProcess = bytesToProcess) * 100f) / 255f
 
 fun Int.getBitAt(position: Int, last: Int = 32) = this shr (last - position) and 1
 

--- a/src/main/kotlin/com/github/eltonvs/obd/command/ParserFunctions.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/ParserFunctions.kt
@@ -3,10 +3,15 @@ package com.github.eltonvs.obd.command
 import kotlin.math.pow
 
 
-fun bytesToInt(bufferedValue: IntArray, start: Int = 2): Long =
-    bufferedValue.drop(start).foldIndexed(0L) { index, total, current ->
-        total + current * 2f.pow((bufferedValue.size - start - index - 1) * 8).toLong()
+fun bytesToInt(bufferedValue: IntArray, start: Int = 2, bytesToProcess: Int = -1): Long {
+    var bufferToProcess = bufferedValue.drop(start)
+    if (bytesToProcess != -1) {
+        bufferToProcess = bufferToProcess.take(bytesToProcess)
     }
+    return bufferToProcess.foldIndexed(0L) { index, total, current ->
+        total + current * 2f.pow((bufferToProcess.size - index - 1) * 8).toLong()
+    }
+}
 
 fun calculatePercentage(bufferedValue: IntArray): Float = (bytesToInt(bufferedValue) * 100f) / 255f
 

--- a/src/main/kotlin/com/github/eltonvs/obd/command/control/Control.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/control/Control.kt
@@ -26,7 +26,7 @@ class TimingAdvanceCommand : ObdCommand() {
     override val pid = "0E"
 
     override val defaultUnit = "°"
-    override val handler = { it: ObdRawResponse -> "%.2f".format(bytesToInt(it.bufferedValue) / 2f - 64) }
+    override val handler = { it: ObdRawResponse -> "%.2f".format(bytesToInt(it.bufferedValue, bytesToProcess = 1) / 2f - 64) }
 }
 
 class VINCommand : ObdCommand() {

--- a/src/main/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
@@ -6,21 +6,21 @@ import com.github.eltonvs.obd.command.bytesToInt
 import com.github.eltonvs.obd.command.calculatePercentage
 
 class CommandedEgrCommand : ObdCommand() {
-  override val tag = "COMMANDED_EGR"
-  override val name = "Commanded EGR"
-  override val mode = "01"
-  override val pid = "2C"
+    override val tag = "COMMANDED_EGR"
+    override val name = "Commanded EGR"
+    override val mode = "01"
+    override val pid = "2C"
 
-  override val defaultUnit = "%"
-  override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val defaultUnit = "%"
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
 }
 
 class EgrErrorCommand : ObdCommand() {
-  override val tag = "EGR_ERROR"
-  override val name = "EGR Error"
-  override val mode = "01"
-  override val pid = "2D"
+    override val tag = "EGR_ERROR"
+    override val name = "EGR Error"
+    override val mode = "01"
+    override val pid = "2D"
 
-  override val defaultUnit = "%"
-  override val handler = { it: ObdRawResponse -> "%.1f".format(bytesToInt(it.bufferedValue) * (100f / 128) - 100) }
+    override val defaultUnit = "%"
+    override val handler = { it: ObdRawResponse -> "%.1f".format(bytesToInt(it.bufferedValue, bytesToProcess = 1) * (100f / 128) - 100) }
 }

--- a/src/main/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
@@ -12,7 +12,7 @@ class CommandedEgrCommand : ObdCommand() {
     override val pid = "2C"
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue, bytesToProcess = 1)) }
 }
 
 class EgrErrorCommand : ObdCommand() {

--- a/src/main/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
@@ -13,7 +13,7 @@ class SpeedCommand : ObdCommand() {
     override val pid = "0D"
 
     override val defaultUnit = "Km/h"
-    override val handler = { it: ObdRawResponse -> bytesToInt(it.bufferedValue).toString() }
+    override val handler = { it: ObdRawResponse -> bytesToInt(it.bufferedValue, bytesToProcess = 1).toString() }
 }
 
 class RPMCommand : ObdCommand() {

--- a/src/main/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
@@ -60,7 +60,7 @@ class LoadCommand : ObdCommand() {
     override val pid = "04"
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue, bytesToProcess = 1)) }
 }
 
 class AbsoluteLoadCommand : ObdCommand() {
@@ -80,7 +80,7 @@ class ThrottlePositionCommand : ObdCommand() {
     override val pid = "11"
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue, bytesToProcess = 1)) }
 }
 
 class RelativeThrottlePositionCommand : ObdCommand() {
@@ -90,5 +90,5 @@ class RelativeThrottlePositionCommand : ObdCommand() {
     override val pid = "45"
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue, bytesToProcess = 1)) }
 }

--- a/src/main/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
@@ -59,7 +59,7 @@ class FuelLevelCommand : ObdCommand() {
     override val pid = "2F"
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue, bytesToProcess = 1)) }
 }
 
 class EthanolLevelCommand : ObdCommand() {
@@ -69,7 +69,7 @@ class EthanolLevelCommand : ObdCommand() {
     override val pid = "52"
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue)) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(calculatePercentage(it.bufferedValue, bytesToProcess = 1)) }
 }
 
 class FuelTrimCommand(fuelTrimBank: FuelTrimBank) : ObdCommand() {

--- a/src/main/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
@@ -22,7 +22,7 @@ class FuelTypeCommand : ObdCommand() {
     override val mode = "01"
     override val pid = "51"
 
-    override val handler = { it: ObdRawResponse -> getFuelType(bytesToInt(it.bufferedValue).toInt()) }
+    override val handler = { it: ObdRawResponse -> getFuelType(bytesToInt(it.bufferedValue, bytesToProcess = 1).toInt()) }
 
     private fun getFuelType(code: Int): String = when (code) {
         0x00 -> "Not Available"
@@ -79,7 +79,7 @@ class FuelTrimCommand(fuelTrimBank: FuelTrimBank) : ObdCommand() {
     override val pid = fuelTrimBank.pid
 
     override val defaultUnit = "%"
-    override val handler = { it: ObdRawResponse -> "%.1f".format(bytesToInt(it.bufferedValue) * (100f / 128) - 100) }
+    override val handler = { it: ObdRawResponse -> "%.1f".format(bytesToInt(it.bufferedValue, bytesToProcess = 1) * (100f / 128) - 100) }
 
     enum class FuelTrimBank(val displayName: String, internal val pid: String) {
         SHORT_TERM_BANK_1("Short Term Fuel Trim Bank 1", "06"),

--- a/src/main/kotlin/com/github/eltonvs/obd/command/fuel/Ratio.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/fuel/Ratio.kt
@@ -5,7 +5,7 @@ import com.github.eltonvs.obd.command.ObdRawResponse
 import com.github.eltonvs.obd.command.bytesToInt
 
 
-private fun calculateFuelAirRatio(rawValue: IntArray): Float = bytesToInt(rawValue) * (2 / 65_536f)
+private fun calculateFuelAirRatio(rawValue: IntArray): Float = bytesToInt(rawValue, bytesToProcess = 2) * (2 / 65_536f)
 
 class CommandedEquivalenceRatioCommand : ObdCommand() {
     override val tag = "COMMANDED_EQUIVALENCE_RATIO"

--- a/src/main/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
@@ -12,7 +12,7 @@ class BarometricPressureCommand : ObdCommand() {
     override val pid = "33"
 
     override val defaultUnit = "kPa"
-    override val handler = { it: ObdRawResponse -> bytesToInt(it.bufferedValue).toString() }
+    override val handler = { it: ObdRawResponse -> bytesToInt(it.bufferedValue, bytesToProcess = 1).toString() }
 }
 
 class IntakeManifoldPressureCommand : ObdCommand() {
@@ -22,7 +22,7 @@ class IntakeManifoldPressureCommand : ObdCommand() {
     override val pid = "0B"
 
     override val defaultUnit = "kPa"
-    override val handler = { it: ObdRawResponse -> bytesToInt(it.bufferedValue).toString() }
+    override val handler = { it: ObdRawResponse -> bytesToInt(it.bufferedValue, bytesToProcess = 1).toString() }
 }
 
 class FuelPressureCommand : ObdCommand() {
@@ -32,7 +32,7 @@ class FuelPressureCommand : ObdCommand() {
     override val pid = "0A"
 
     override val defaultUnit = "kPa"
-    override val handler = { it: ObdRawResponse -> (bytesToInt(it.bufferedValue) * 3).toString() }
+    override val handler = { it: ObdRawResponse -> (bytesToInt(it.bufferedValue, bytesToProcess = 1) * 3).toString() }
 }
 
 class FuelRailPressureCommand : ObdCommand() {

--- a/src/main/kotlin/com/github/eltonvs/obd/command/temperature/Temperature.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/temperature/Temperature.kt
@@ -5,7 +5,7 @@ import com.github.eltonvs.obd.command.ObdRawResponse
 import com.github.eltonvs.obd.command.bytesToInt
 
 
-private fun calculateTemperature(rawValue: IntArray): Float = bytesToInt(rawValue) - 40f
+private fun calculateTemperature(rawValue: IntArray): Float = bytesToInt(rawValue, bytesToProcess = 1) - 40f
 
 class AirIntakeTemperatureCommand : ObdCommand() {
     override val tag = "AIR_INTAKE_TEMPERATURE"

--- a/src/test/kotlin/com/github/eltonvs/obd/command/ParserFunctions.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/ParserFunctions.kt
@@ -1,0 +1,40 @@
+package com.github.eltonvs.obd.command
+
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+
+@RunWith(Parameterized::class)
+class BytesToIntParameterizedTests(
+    private val bufferedValue: IntArray,
+    private val start: Int,
+    private val bytesToProcess: Int,
+    private val expected: Long
+) {
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun values() = listOf(
+            arrayOf(intArrayOf(0x0), 0, -1, 0),
+            arrayOf(intArrayOf(0x1), 0, -1, 1),
+            arrayOf(intArrayOf(0x1), 0, 1, 1),
+            arrayOf(intArrayOf(0x10), 0, -1, 16),
+            arrayOf(intArrayOf(0x11), 0, -1, 17),
+            arrayOf(intArrayOf(0xFF), 0, -1, 255),
+            arrayOf(intArrayOf(0xFF, 0xFF), 0, -1, 65535),
+            arrayOf(intArrayOf(0xFF, 0xFF), 0, 1, 255),
+            arrayOf(intArrayOf(0xFF, 0x00), 0, -1, 65280),
+            arrayOf(intArrayOf(0xFF, 0x00), 0, 1, 255),
+            arrayOf(intArrayOf(0x41, 0x0D, 0x40), 2, -1, 64),
+            arrayOf(intArrayOf(0x41, 0x0D, 0x40, 0xFF), 2, 1, 64)
+        )
+    }
+
+    @Test
+    fun `test valid results for bytesToInt`() {
+        val result = bytesToInt(bufferedValue, start = start, bytesToProcess = bytesToProcess)
+        assertEquals(expected, result)
+    }
+}

--- a/src/test/kotlin/com/github/eltonvs/obd/command/control/Control.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/control/Control.kt
@@ -38,7 +38,8 @@ class TimingAdvanceCommandParameterizedTests(private val rawValue: String, priva
         fun values() = listOf(
             arrayOf("410E70", -8f),
             arrayOf("410E00", -64f),
-            arrayOf("410EFF", 63.5f)
+            arrayOf("410EFF", 63.5f),
+            arrayOf("410EFFFF", 63.5f)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
@@ -8,47 +8,48 @@ import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
 class CommandedEgrCommandParameterizedTests(private val rawValue: String, private val expected: Float) {
-  companion object {
-    @JvmStatic
-    @Parameterized.Parameters
-    fun values() = listOf(
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun values() = listOf(
             arrayOf("414545", 27.1f),
             arrayOf("414500", 0f),
             arrayOf("4145FF", 100f)
-    )
-  }
-
-  @Test
-  fun `test valid commanded egr responses handler`() {
-    val rawResponse = ObdRawResponse(value = rawValue, elapsedTime = 0)
-    val obdResponse = CommandedEgrCommand().run {
-      handleResponse(rawResponse)
+        )
     }
-    assertEquals("%.1f".format(expected) + '%', obdResponse.formattedValue)
-  }
+
+    @Test
+    fun `test valid commanded egr responses handler`() {
+        val rawResponse = ObdRawResponse(value = rawValue, elapsedTime = 0)
+        val obdResponse = CommandedEgrCommand().run {
+            handleResponse(rawResponse)
+        }
+        assertEquals("%.1f".format(expected) + '%', obdResponse.formattedValue)
+    }
 }
 
 @RunWith(Parameterized::class)
 class EgrErrorCommandParameterizedTests(private val rawValue: String, private val expected: Float) {
-  companion object {
-    @JvmStatic
-    @Parameterized.Parameters
-    fun values() = listOf(
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun values() = listOf(
             arrayOf("410610", -87.5f),
             arrayOf("410643", -47.7f),
             arrayOf("410680", 0f),
             arrayOf("4106C8", 56.25f),
             arrayOf("410600", -100f),
-            arrayOf("4106FF", 99.2f)
-    )
-  }
-
-  @Test
-  fun `test valid egr error responses handler`() {
-    val rawResponse = ObdRawResponse(value = rawValue, elapsedTime = 0)
-    val obdResponse = EgrErrorCommand().run {
-      handleResponse(rawResponse)
+            arrayOf("4106FF", 99.2f),
+            arrayOf("4106FFFF", 99.2f)
+        )
     }
-    assertEquals("%.1f".format(expected) + '%', obdResponse.formattedValue)
-  }
+
+    @Test
+    fun `test valid egr error responses handler`() {
+        val rawResponse = ObdRawResponse(value = rawValue, elapsedTime = 0)
+        val obdResponse = EgrErrorCommand().run {
+            handleResponse(rawResponse)
+        }
+        assertEquals("%.1f".format(expected) + '%', obdResponse.formattedValue)
+    }
 }

--- a/src/test/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/egr/Egr.kt
@@ -14,7 +14,8 @@ class CommandedEgrCommandParameterizedTests(private val rawValue: String, privat
         fun values() = listOf(
             arrayOf("414545", 27.1f),
             arrayOf("414500", 0f),
-            arrayOf("4145FF", 100f)
+            arrayOf("4145FF", 100f),
+            arrayOf("4145FFFF", 100f)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
@@ -113,7 +113,8 @@ class LoadCommandParameterizedTests(private val rawValue: String, private val ex
         fun values() = listOf(
             arrayOf("410410", 6.3f),
             arrayOf("410400", 0f),
-            arrayOf("4104FF", 100f)
+            arrayOf("4104FF", 100f),
+            arrayOf("4104FFFF", 100f)
         )
     }
 
@@ -160,7 +161,8 @@ class ThrottlePositionCommandParameterizedTests(private val rawValue: String, pr
         fun values() = listOf(
             arrayOf("411111", 6.7f),
             arrayOf("411100", 0f),
-            arrayOf("4111FF", 100f)
+            arrayOf("4111FF", 100f),
+            arrayOf("4111FFFF", 100f)
         )
     }
 
@@ -183,7 +185,8 @@ class RelativeThrottlePositionCommandParameterizedTests(private val rawValue: St
         fun values() = listOf(
             arrayOf("414545", 27.1f),
             arrayOf("414500", 0f),
-            arrayOf("4145FF", 100f)
+            arrayOf("4145FF", 100f),
+            arrayOf("4145FFFF", 100f)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
@@ -16,7 +16,8 @@ class SpeedCommandParameterizedTests(private val rawValue: String, private val e
             arrayOf("410D15", 21),
             arrayOf("410D40", 64),
             arrayOf("410D00", 0),
-            arrayOf("410DFF", 255)
+            arrayOf("410DFF", 255),
+            arrayOf("410DFFFF", 255)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
@@ -60,7 +60,9 @@ class FuelTypeCommandParameterizedTests(private val rawValue: String, private va
             arrayOf("415114", "Hybrid Electric"),
             arrayOf("415115", "Hybrid Mixed"),
             arrayOf("415116", "Hybrid Regenerative"),
-            arrayOf("4151FF", "Unknown")
+            arrayOf("415116FF", "Hybrid Regenerative"),
+            arrayOf("4151FF", "Unknown"),
+            arrayOf("4151FFFF", "Unknown")
         )
     }
 
@@ -119,7 +121,8 @@ class GenericFuelTrimCommandParameterizedTests(private val rawValue: String, pri
             arrayOf("410680", 0f),
             arrayOf("4106C8", 56.25f),
             arrayOf("410600", -100f),
-            arrayOf("4106FF", 99.2f)
+            arrayOf("4106FF", 99.2f),
+            arrayOf("4106FFFF", 99.2f)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/fuel/Fuel.kt
@@ -86,7 +86,8 @@ class GenericFuelLevelCommandParameterizedTests(private val rawValue: String, pr
             arrayOf("412F10", 6.3f),
             arrayOf("412FC8", 78.4f),
             arrayOf("412F00", 0f),
-            arrayOf("412FFF", 100f)
+            arrayOf("412FFF", 100f),
+            arrayOf("412FFFFF", 100f)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/fuel/Ratio.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/fuel/Ratio.kt
@@ -17,7 +17,8 @@ class CommandedEquivalenceRatioCommandParameterizedTests(private val rawValue: S
             arrayOf("41444040", 0.5f),
             arrayOf("41448080", 1f),
             arrayOf("41440000", 0f),
-            arrayOf("4144FFFF", 2f)
+            arrayOf("4144FFFF", 2f),
+            arrayOf("4144FFFFFFFF", 2f)
         )
     }
 
@@ -42,7 +43,8 @@ class FuelAirEquivalenceRatioCommandParameterizedTests(private val rawValue: Str
             arrayOf("41344040", 0.5f),
             arrayOf("41348080", 1f),
             arrayOf("41340000", 0f),
-            arrayOf("4134FFFF", 2f)
+            arrayOf("4134FFFF", 2f),
+            arrayOf("4134FFFFFFFF", 2f)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/pressure/Pressure.kt
@@ -18,7 +18,8 @@ class BarometricPressureCommandParameterizedTests(private val rawValue: String, 
             arrayOf("413364", 100),
             arrayOf("413380", 128),
             arrayOf("413300", 0),
-            arrayOf("4133FF", 255)
+            arrayOf("4133FF", 255),
+            arrayOf("4133FFFF", 255)
         )
     }
 
@@ -45,7 +46,8 @@ class IntakeManifoldPressureCommandParameterizedTests(private val rawValue: Stri
             arrayOf("410B64", 100),
             arrayOf("410B80", 128),
             arrayOf("410B00", 0),
-            arrayOf("410BFF", 255)
+            arrayOf("410BFF", 255),
+            arrayOf("410BFFFF", 255)
         )
     }
 
@@ -70,7 +72,8 @@ class FuelPressureCommandParameterizedTests(private val rawValue: String, privat
             arrayOf("410A64", 300),
             arrayOf("410A80", 384),
             arrayOf("410A00", 0),
-            arrayOf("410AFF", 765)
+            arrayOf("410AFF", 765),
+            arrayOf("410AFFFF", 765)
         )
     }
 

--- a/src/test/kotlin/com/github/eltonvs/obd/command/temperature/Temperature.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/temperature/Temperature.kt
@@ -16,7 +16,8 @@ class AirIntakeTemperatureCommandParameterizedTests(private val rawValue: String
             arrayOf("410F40", 24f),
             arrayOf("410F5D", 53f),
             arrayOf("410F00", -40f),
-            arrayOf("410FFF", 215f)
+            arrayOf("410FFF", 215f),
+            arrayOf("410FFFFF", 215f)
         )
     }
 
@@ -40,7 +41,8 @@ class AmbientAirTemperatureCommandParameterizedTests(private val rawValue: Strin
             arrayOf("414640", 24f),
             arrayOf("41465D", 53f),
             arrayOf("414600", -40f),
-            arrayOf("4146FF", 215f)
+            arrayOf("4146FF", 215f),
+            arrayOf("4146FFFF", 215f)
         )
     }
 
@@ -64,7 +66,8 @@ class EngineCoolantTemperatureCommandParameterizedTests(private val rawValue: St
             arrayOf("410540", 24f),
             arrayOf("41055D", 53f),
             arrayOf("410500", -40f),
-            arrayOf("4105FF", 215f)
+            arrayOf("4105FF", 215f),
+            arrayOf("4105FFFF", 215f)
         )
     }
 
@@ -88,7 +91,8 @@ class OilTemperatureCommandParameterizedTests(private val rawValue: String, priv
             arrayOf("415C40", 24f),
             arrayOf("415C5D", 53f),
             arrayOf("415C00", -40f),
-            arrayOf("415CFF", 215f)
+            arrayOf("415CFF", 215f),
+            arrayOf("415CFFFF", 215f)
         )
     }
 


### PR DESCRIPTION
This should provide a solution for #15

The problem was that the `bytesToInt` function was generic and assumed that only the required bytes would be returned from the OBD device.
But this isn't true, as sometimes, residual values (noise) are also returned, and need to be ignored by the parser function.

This solution adds a  parameter to the `bytesToInt` function in order to process just the `bytesToProcess` amount of bytes from a given input.

All commands that should rely just on the first byte were also updated:
- `TIMING_ADVANCE`
- `COMMANDED_EGR`
- `EGR_ERROR`
- `SPEED`
- `ENGINE_LOAD`
- `THROTTLE_POSITION`
- `RELATIVE_THROTTLE_POSITION`
- `FUEL_TYPE`
- `FUEL_LEVEL`
- `ETHANOL_LEVEL`
- `SHORT_TERM_BANK_1` (`FuelTrimCommand`)
- `SHORT_TERM_BANK_2` (`FuelTrimCommand`)
- `LONG_TERM_BANK_1` (`FuelTrimCommand`)
- `LONG_TERM_BANK_2` (`FuelTrimCommand`)
- `COMMANDED_EQUIVALENCE_RATIO`
- `OXYGEN_SENSOR_1` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_2` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_3` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_4` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_5` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_6` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_7` (`FuelAirEquivalenceRatioCommand`)
- `OXYGEN_SENSOR_8` (`FuelAirEquivalenceRatioCommand`)
- `BAROMETRIC_PRESSURE`
- `INTAKE_MANIFOLD_PRESSURE`
- `FUEL_PRESSURE`
- `AIR_INTAKE_TEMPERATURE`
- `AMBIENT_AIR_TEMPERATURE`
- `ENGINE_COOLANT_TEMPERATURE`
- `ENGINE_OIL_TEMPERATURE`