### PR TITLE
feat: Remove JCenter and use JitPack instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,18 @@ This is a flexible API that allows developers to plug-in to any connection inter
 
 ## Installation
 
-You can download a jar from GitHub's [releases page](https://github.com/eltonvs/kotlin-obd-api/releases).
 
-Or use Gradle:
+### Gradle
 
+In your root `build.gradle` file, at the end of repositories:
+```gradle
+repositories {
+  ...
+  maven { url 'https://jitpack.io' }
+}
+```
+
+Add the dependency
 ```gradle
 dependencies {
   ...
@@ -34,8 +42,19 @@ dependencies {
 }
 ```
 
-Or Maven:
+### Maven
 
+Add jitpack to the repositories section
+```xml
+<repositories>
+  <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+  </repository>
+</repositories>
+```
+
+Add the dependency
 ```xml
 <dependency>
   <groupId>com.github.eltonvs</groupId>
@@ -44,6 +63,9 @@ Or Maven:
 </dependency>
 ```
 
+### Manual
+
+You can download a jar from GitHub's [releases page](https://github.com/eltonvs/kotlin-obd-api/releases).
 
 ## Basic Usage
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,66 +1,41 @@
-import com.jfrog.bintray.gradle.BintrayExtension
-import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 val publicationName = "kotlin-obd-api"
 
 plugins {
-    kotlin("jvm") version "1.3.61"
+    kotlin("jvm") version "1.6.21"
     `maven-publish`
-    id("com.jfrog.bintray") version "1.8.4"
 }
 
 group = "com.github.eltonvs"
 version = "1.1.1"
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
+    implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3")
     testImplementation(kotlin("test"))
     testImplementation(kotlin("test-junit"))
 }
 
-val sourcesJar by tasks.creating(Jar::class) {
-    classifier = "sources"
-    from(sourceSets.getByName("main").allSource)
+tasks {
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+    compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
 }
 
 publishing {
     publications {
-        create<MavenPublication>(publicationName) {
+        create<MavenPublication>("maven") {
             groupId = project.group.toString()
             artifactId = project.name
             version = project.version.toString()
+
             from(components["java"])
-            artifact(sourcesJar)
         }
     }
-}
-
-bintray {
-    user = project.findProperty("bintrayUser").toString()
-    key = project.findProperty("bintrayKey").toString()
-    dryRun = false
-    publish = true
-    setPublications(publicationName)
-    pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
-        repo = "maven"
-        name = project.name
-        desc = "A Kotlin OBD-II API for reading engine data"
-        websiteUrl = "https://github.com/eltonvs/${project.name}.git"
-        issueTrackerUrl = "https://github.com/eltonvs/${project.name}/issues"
-        vcsUrl = "https://github.com/eltonvs/${project.name}.git"
-        version.vcsTag = "v${project.version}"
-        setLicenses("Apache-2.0")
-        setLabels("kotlin", "obd", "vehicle", "car", "obd-api")
-        publicDownloadNumbers = true
-    })
-}
-
-tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/src/main/kotlin/com/github/eltonvs/obd/command/Exceptions.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/Exceptions.kt
@@ -11,7 +11,7 @@ import com.github.eltonvs.obd.command.RegexPatterns.UNSUPPORTED_COMMAND_MESSAGE_
 import com.github.eltonvs.obd.command.RegexPatterns.WHITESPACE_PATTERN
 
 
-private fun String.sanitize(): String = removeAll(WHITESPACE_PATTERN, this).toUpperCase()
+private fun String.sanitize(): String = removeAll(WHITESPACE_PATTERN, this).uppercase()
 
 abstract class BadResponseException(private val command: ObdCommand, private val response: ObdRawResponse) :
     RuntimeException() {

--- a/src/main/kotlin/com/github/eltonvs/obd/command/at/Info.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/at/Info.kt
@@ -31,7 +31,7 @@ class IgnitionMonitorCommand : ATCommand() {
     override val name = "Ignition Monitor"
     override val pid = "IGN"
 
-    override val handler = { it: ObdRawResponse -> it.value.trim().toUpperCase() }
+    override val handler = { it: ObdRawResponse -> it.value.trim().uppercase() }
 }
 
 class AdapterVoltageCommand : ATCommand() {

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -37,7 +37,7 @@ class ObdDeviceConnection(private val inputStream: InputStream, private val outp
     }
 
     private fun runCommand(command: ObdCommand, delayTime: Long): ObdRawResponse {
-        var rawData = ""
+        var rawData: String
         val elapsedTime = measureTimeMillis {
             sendCommand(command, delayTime)
             rawData = readRawData()
@@ -64,7 +64,7 @@ class ObdDeviceConnection(private val inputStream: InputStream, private val outp
             if (b < 0) {
                 break
             }
-            c = b.toChar()
+            c = b.toInt().toChar()
             if (c == '>') {
                 break
             }


### PR DESCRIPTION
The JCenter repository is read-only now, this PR makes this lib compatible with JitPack.

Also, the kotlin & gradle versions were upgraded.