### PR TITLE
Reduce response read latency and normalize ELM327 AT command formatting

### DIFF
--- a/LLM_CONTEXT.md
+++ b/LLM_CONTEXT.md
@@ -44,6 +44,7 @@ Execution model:
 - `run` is `suspend`
 - Commands are serialized per connection instance (internal `Mutex`)
 - Cache is keyed by command class + raw command when `useCache = true`
+- `maxRetries` is kept for compatibility and maps to a legacy response timeout budget of `maxRetries * 500ms`
 
 ### Response types
 
@@ -64,7 +65,9 @@ Execution model:
 obdConnection.run(ResetAdapterCommand())
 obdConnection.run(SetEchoCommand(Switcher.OFF))
 obdConnection.run(SetLineFeedCommand(Switcher.OFF))
+obdConnection.run(SetSpacesCommand(Switcher.OFF))
 obdConnection.run(SetHeadersCommand(Switcher.OFF))
+obdConnection.run(SetAdaptiveTimingCommand(AdaptiveTimingMode.AUTO_1))
 ```
 
 Depending on adapter/car, protocol selection may be explicit:

--- a/README.md
+++ b/README.md
@@ -83,9 +83,16 @@ You can download a jar from GitHub's [releases page](https://github.com/eltonvs/
 Get an `InputStream` and an `OutputStream` from your connection interface and create an `ObdDeviceConnection` instance.
 
 ```kotlin
+import com.github.eltonvs.obd.command.AdaptiveTimingMode
+import com.github.eltonvs.obd.command.ObdProtocols
 import com.github.eltonvs.obd.command.Switcher
 import com.github.eltonvs.obd.command.at.ResetAdapterCommand
+import com.github.eltonvs.obd.command.at.SelectProtocolCommand
+import com.github.eltonvs.obd.command.at.SetAdaptiveTimingCommand
 import com.github.eltonvs.obd.command.at.SetEchoCommand
+import com.github.eltonvs.obd.command.at.SetHeadersCommand
+import com.github.eltonvs.obd.command.at.SetLineFeedCommand
+import com.github.eltonvs.obd.command.at.SetSpacesCommand
 import com.github.eltonvs.obd.command.control.TroubleCodesCommand
 import com.github.eltonvs.obd.command.control.VINCommand
 import com.github.eltonvs.obd.command.engine.RPMCommand
@@ -96,9 +103,14 @@ import java.io.OutputStream
 suspend fun readObd(inputStream: InputStream, outputStream: OutputStream) {
     val obdConnection = ObdDeviceConnection(inputStream, outputStream)
 
-    // Typical ELM327 setup
+    // Recommended low-noise ELM327 setup
     obdConnection.run(ResetAdapterCommand())
     obdConnection.run(SetEchoCommand(Switcher.OFF))
+    obdConnection.run(SetLineFeedCommand(Switcher.OFF))
+    obdConnection.run(SetSpacesCommand(Switcher.OFF))
+    obdConnection.run(SetHeadersCommand(Switcher.OFF))
+    obdConnection.run(SetAdaptiveTimingCommand(AdaptiveTimingMode.AUTO_1))
+    obdConnection.run(SelectProtocolCommand(ObdProtocols.AUTO))
 
     val rpm = obdConnection.run(RPMCommand())
     val vin = obdConnection.run(VINCommand(), useCache = true)
@@ -114,7 +126,16 @@ suspend fun readObd(inputStream: InputStream, outputStream: OutputStream) {
 - `command`: any `ObdCommand`
 - `useCache` (default `false`): reuses previous raw responses for identical commands
 - `delayTime` (default `0`): delay in milliseconds after sending command
-- `maxRetries` (default `5`): read polling retries before giving up
+- `maxRetries` (default `5`): legacy compatibility timeout budget mapped internally to `maxRetries * 500ms`
+
+Recommended setup profile for faster, lower-noise sessions:
+- `ResetAdapterCommand()`
+- `SetEchoCommand(Switcher.OFF)`
+- `SetLineFeedCommand(Switcher.OFF)`
+- `SetSpacesCommand(Switcher.OFF)`
+- `SetHeadersCommand(Switcher.OFF)`
+- `SetAdaptiveTimingCommand(AdaptiveTimingMode.AUTO_1)` by default, or `AUTO_2` if you want more aggressive adapter-side timing
+- `SelectProtocolCommand(knownProtocol)` when the protocol is known, otherwise `SelectProtocolCommand(ObdProtocols.AUTO)`
 
 Runtime note: call `run()` from a background coroutine context (for example `Dispatchers.IO`). On Android, do not call it from the main thread.
 

--- a/src/main/kotlin/com/github/eltonvs/obd/command/at/Mutations.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/at/Mutations.kt
@@ -21,7 +21,7 @@ class SetAdaptiveTimingCommand(
 ) : ATCommand() {
     override val tag = "SET_ADAPTIVE_TIMING_${value.name}"
     override val name = "Set Adaptive Timing Control ${value.displayName}"
-    override val pid = "AT ${value.command}"
+    override val pid = "AT${value.command}"
 }
 
 class SetEchoCommand(
@@ -61,5 +61,5 @@ class SetTimeoutCommand(
 ) : ATCommand() {
     override val tag = "SET_TIMEOUT"
     override val name = "Set Timeout - $timeout"
-    override val pid = "ST ${Integer.toHexString(TIMEOUT_MASK and timeout)}"
+    override val pid = "ST ${(TIMEOUT_MASK and timeout).toString(radix = 16).uppercase().padStart(2, '0')}"
 }

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -19,6 +19,11 @@ import kotlin.system.measureTimeMillis
 private const val LEGACY_READ_RETRY_DELAY_MS = 500L
 private const val READ_POLL_INTERVAL_MS = 10L
 
+private data class ReadProgress(
+    val interByteDeadline: Long,
+    val shouldStop: Boolean,
+)
+
 class ObdDeviceConnection
     @JvmOverloads
     constructor(
@@ -34,8 +39,7 @@ class ObdDeviceConnection
             useCache: Boolean = false,
             delayTime: Long = 0,
             maxRetries: Int = 5,
-        ): ObdResponse =
-            runWithReadPolicy(command, useCache, delayTime, legacyReadPolicy(maxRetries))
+        ): ObdResponse = runWithReadPolicy(command, useCache, delayTime, legacyReadPolicy(maxRetries))
 
         internal suspend fun runWithReadPolicy(
             command: ObdCommand,
@@ -90,37 +94,24 @@ class ObdDeviceConnection
                 val responseDeadline = deadlineFromNow(readPolicy.responseTimeoutMs)
                 var interByteDeadline = responseDeadline
                 val response = StringBuilder()
-                var isReading = true
+                var shouldStop = false
 
-                while (isReading) {
-                    if (inputStream.available() > 0) {
-                        while (inputStream.available() > 0) {
-                            val byteValue = inputStream.read()
-                            if (byteValue == -1) {
-                                isReading = false
-                                break
-                            }
-                            val charValue = byteValue.toChar()
-                            if (charValue == '>') {
-                                isReading = false
-                                break
+                while (!shouldStop) {
+                    val readProgress = drainAvailableBytes(response, interByteDeadline, readPolicy)
+                    interByteDeadline = readProgress.interByteDeadline
+                    shouldStop = readProgress.shouldStop
+                    if (!shouldStop) {
+                        val now = System.nanoTime()
+                        val nextDeadline =
+                            if (response.isNotEmpty()) {
+                                minOf(responseDeadline, interByteDeadline)
                             } else {
-                                response.append(charValue)
-                                interByteDeadline = deadlineFromNow(readPolicy.interByteTimeoutMs)
+                                responseDeadline
                             }
+                        shouldStop = now >= nextDeadline
+                        if (!shouldStop) {
+                            delay(nextPollDelayMs(nextDeadline - now))
                         }
-                    }
-
-                    if (!isReading) {
-                        break
-                    }
-
-                    val now = System.nanoTime()
-                    val nextDeadline = if (response.isNotEmpty()) minOf(responseDeadline, interByteDeadline) else responseDeadline
-                    if (now >= nextDeadline) {
-                        isReading = false
-                    } else {
-                        delay(nextPollDelayMs(nextDeadline - now))
                     }
                 }
                 cleanResponse(response)
@@ -131,7 +122,14 @@ class ObdDeviceConnection
             return "$classKey:${command.rawCommand}"
         }
 
-        private fun cleanResponse(response: StringBuilder): String = removeAll(SEARCHING_PATTERN, response.toString()).trim()
+        private fun cleanResponse(response: StringBuilder): String {
+            val cleanedResponse =
+                removeAll(
+                    SEARCHING_PATTERN,
+                    response.toString(),
+                )
+            return cleanedResponse.trim()
+        }
 
         private fun legacyReadPolicy(maxRetries: Int): ObdReadPolicy {
             require(maxRetries >= 0) { "maxRetries must be >= 0" }
@@ -141,7 +139,34 @@ class ObdDeviceConnection
             )
         }
 
-        private fun deadlineFromNow(durationMs: Long): Long = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(durationMs)
+        private fun drainAvailableBytes(
+            response: StringBuilder,
+            interByteDeadline: Long,
+            readPolicy: ObdReadPolicy,
+        ): ReadProgress {
+            var nextInterByteDeadline = interByteDeadline
+            var shouldStop = false
+            while (inputStream.available() > 0 && !shouldStop) {
+                val byteValue = inputStream.read()
+                if (byteValue == -1) {
+                    shouldStop = true
+                } else {
+                    val charValue = byteValue.toChar()
+                    if (charValue == '>') {
+                        shouldStop = true
+                    } else {
+                        response.append(charValue)
+                        nextInterByteDeadline = deadlineFromNow(readPolicy.interByteTimeoutMs)
+                    }
+                }
+            }
+            return ReadProgress(nextInterByteDeadline, shouldStop)
+        }
+
+        private fun deadlineFromNow(durationMs: Long): Long {
+            val durationNanos = TimeUnit.MILLISECONDS.toNanos(durationMs)
+            return System.nanoTime() + durationNanos
+        }
 
         private fun nextPollDelayMs(remainingNanos: Long): Long {
             val remainingMs = TimeUnit.NANOSECONDS.toMillis(remainingNanos)

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -13,9 +13,11 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.TimeUnit
 import kotlin.system.measureTimeMillis
 
-private const val READ_RETRY_DELAY_MS = 500L
+private const val LEGACY_READ_RETRY_DELAY_MS = 500L
+private const val READ_POLL_INTERVAL_MS = 10L
 
 class ObdDeviceConnection
     @JvmOverloads
@@ -33,13 +35,21 @@ class ObdDeviceConnection
             delayTime: Long = 0,
             maxRetries: Int = 5,
         ): ObdResponse =
+            runWithReadPolicy(command, useCache, delayTime, legacyReadPolicy(maxRetries))
+
+        internal suspend fun runWithReadPolicy(
+            command: ObdCommand,
+            useCache: Boolean = false,
+            delayTime: Long = 0,
+            readPolicy: ObdReadPolicy,
+        ): ObdResponse =
             runMutex.withLock {
                 val cacheKey = cacheKey(command)
                 val obdRawResponse =
                     if (useCache && responseCache[cacheKey] != null) {
                         responseCache.getValue(cacheKey)
                     } else {
-                        runCommand(command, delayTime, maxRetries).also {
+                        runCommand(command, delayTime, readPolicy).also {
                             if (useCache) {
                                 responseCache[cacheKey] = it
                             }
@@ -51,13 +61,13 @@ class ObdDeviceConnection
         private suspend fun runCommand(
             command: ObdCommand,
             delayTime: Long,
-            maxRetries: Int,
+            readPolicy: ObdReadPolicy,
         ): ObdRawResponse {
             var rawData = ""
             val elapsedTime =
                 measureTimeMillis {
                     sendCommand(command, delayTime)
-                    rawData = readRawData(maxRetries)
+                    rawData = readRawData(readPolicy)
                 }
             return ObdRawResponse(rawData, elapsedTime)
         }
@@ -75,40 +85,66 @@ class ObdDeviceConnection
             }
         }
 
-        private suspend fun readRawData(maxRetries: Int): String =
+        private suspend fun readRawData(readPolicy: ObdReadPolicy): String =
             withContext(ioDispatcher) {
-                val res = StringBuilder()
-                var retriesCount = 0
-
-                // Read until '>' arrives, stream ends (-1), or retries are exhausted.
+                val responseDeadline = deadlineFromNow(readPolicy.responseTimeoutMs)
+                var interByteDeadline = responseDeadline
+                val response = StringBuilder()
                 var isReading = true
+
                 while (isReading) {
                     if (inputStream.available() > 0) {
-                        val byteValue = inputStream.read()
-                        if (byteValue == -1) {
-                            isReading = false
-                        } else {
+                        while (inputStream.available() > 0) {
+                            val byteValue = inputStream.read()
+                            if (byteValue == -1) {
+                                isReading = false
+                                break
+                            }
                             val charValue = byteValue.toChar()
                             if (charValue == '>') {
                                 isReading = false
+                                break
                             } else {
-                                res.append(charValue)
+                                response.append(charValue)
+                                interByteDeadline = deadlineFromNow(readPolicy.interByteTimeoutMs)
                             }
                         }
+                    }
+
+                    if (!isReading) {
+                        break
+                    }
+
+                    val now = System.nanoTime()
+                    val nextDeadline = if (response.isNotEmpty()) minOf(responseDeadline, interByteDeadline) else responseDeadline
+                    if (now >= nextDeadline) {
+                        isReading = false
                     } else {
-                        if (retriesCount >= maxRetries) {
-                            isReading = false
-                        } else {
-                            retriesCount += 1
-                            delay(READ_RETRY_DELAY_MS)
-                        }
+                        delay(nextPollDelayMs(nextDeadline - now))
                     }
                 }
-                removeAll(SEARCHING_PATTERN, res.toString()).trim()
+                cleanResponse(response)
             }
 
         private fun cacheKey(command: ObdCommand): String {
             val classKey = command::class.qualifiedName ?: command.javaClass.name
             return "$classKey:${command.rawCommand}"
+        }
+
+        private fun cleanResponse(response: StringBuilder): String = removeAll(SEARCHING_PATTERN, response.toString()).trim()
+
+        private fun legacyReadPolicy(maxRetries: Int): ObdReadPolicy {
+            require(maxRetries >= 0) { "maxRetries must be >= 0" }
+            return ObdReadPolicy(
+                responseTimeoutMs = maxRetries.toLong() * LEGACY_READ_RETRY_DELAY_MS,
+                interByteTimeoutMs = LEGACY_READ_RETRY_DELAY_MS,
+            )
+        }
+
+        private fun deadlineFromNow(durationMs: Long): Long = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(durationMs)
+
+        private fun nextPollDelayMs(remainingNanos: Long): Long {
+            val remainingMs = TimeUnit.NANOSECONDS.toMillis(remainingNanos)
+            return minOf(READ_POLL_INTERVAL_MS, maxOf(1L, remainingMs))
         }
     }

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnection.kt
@@ -133,9 +133,10 @@ class ObdDeviceConnection
 
         private fun legacyReadPolicy(maxRetries: Int): ObdReadPolicy {
             require(maxRetries >= 0) { "maxRetries must be >= 0" }
+            val timeoutMs = maxRetries.toLong() * LEGACY_READ_RETRY_DELAY_MS
             return ObdReadPolicy(
-                responseTimeoutMs = maxRetries.toLong() * LEGACY_READ_RETRY_DELAY_MS,
-                interByteTimeoutMs = LEGACY_READ_RETRY_DELAY_MS,
+                responseTimeoutMs = timeoutMs,
+                interByteTimeoutMs = timeoutMs,
             )
         }
 

--- a/src/main/kotlin/com/github/eltonvs/obd/connection/ObdReadPolicy.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/connection/ObdReadPolicy.kt
@@ -1,0 +1,11 @@
+package com.github.eltonvs.obd.connection
+
+internal data class ObdReadPolicy(
+    val responseTimeoutMs: Long,
+    val interByteTimeoutMs: Long,
+) {
+    init {
+        require(responseTimeoutMs >= 0) { "responseTimeoutMs must be >= 0" }
+        require(interByteTimeoutMs >= 0) { "interByteTimeoutMs must be >= 0" }
+    }
+}

--- a/src/test/kotlin/com/github/eltonvs/obd/command/at/MutationsTest.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/at/MutationsTest.kt
@@ -1,0 +1,22 @@
+package com.github.eltonvs.obd.command.at
+
+import com.github.eltonvs.obd.command.AdaptiveTimingMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MutationsTest {
+    @Test
+    fun `adaptive timing command uses the expected AT syntax`() {
+        assertEquals("AT AT1", SetAdaptiveTimingCommand(AdaptiveTimingMode.AUTO_1).rawCommand)
+    }
+
+    @Test
+    fun `timeout command uses uppercase zero padded hex`() {
+        assertEquals("AT ST 0A", SetTimeoutCommand(10).rawCommand)
+    }
+
+    @Test
+    fun `timeout command masks values to one byte`() {
+        assertEquals("AT ST 23", SetTimeoutCommand(0x123).rawCommand)
+    }
+}

--- a/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
@@ -126,7 +126,10 @@ class ObdDeviceConnectionTest {
                 )
 
             assertEquals("410D40", response.value)
-            assertTrue(response.rawResponse.elapsedTime < 250, "expected elapsed time below 250ms, was ${response.rawResponse.elapsedTime}ms")
+            assertTrue(
+                response.rawResponse.elapsedTime < 250,
+                "expected elapsed time below 250ms, was ${response.rawResponse.elapsedTime}ms",
+            )
         }
 
     @Test
@@ -193,8 +196,14 @@ class ObdDeviceConnectionTest {
             withTimeout(1_500) {
                 val response = connection.run(command, maxRetries = 1)
                 assertEquals("", response.value)
-                assertTrue(response.rawResponse.elapsedTime >= 450, "expected at least ~500ms, was ${response.rawResponse.elapsedTime}ms")
-                assertTrue(response.rawResponse.elapsedTime < 1_200, "expected legacy timeout below 1200ms, was ${response.rawResponse.elapsedTime}ms")
+                assertTrue(
+                    response.rawResponse.elapsedTime >= 450,
+                    "expected at least ~500ms, was ${response.rawResponse.elapsedTime}ms",
+                )
+                assertTrue(
+                    response.rawResponse.elapsedTime < 1_200,
+                    "expected legacy timeout below 1200ms, was ${response.rawResponse.elapsedTime}ms",
+                )
             }
         }
 
@@ -207,10 +216,20 @@ class ObdDeviceConnectionTest {
             val command = TestObdCommand(tag = "SPEED", pid = "0D")
 
             withTimeout(500) {
-                val response = connection.runWithReadPolicy(command, readPolicy = ObdReadPolicy(responseTimeoutMs = 40, interByteTimeoutMs = 25))
+                val response =
+                    connection.runWithReadPolicy(
+                        command,
+                        readPolicy = ObdReadPolicy(responseTimeoutMs = 40, interByteTimeoutMs = 25),
+                    )
                 assertEquals("", response.value)
-                assertTrue(response.rawResponse.elapsedTime >= 30, "expected explicit timeout near 40ms, was ${response.rawResponse.elapsedTime}ms")
-                assertTrue(response.rawResponse.elapsedTime < 250, "expected explicit timeout below 250ms, was ${response.rawResponse.elapsedTime}ms")
+                assertTrue(
+                    response.rawResponse.elapsedTime >= 30,
+                    "expected explicit timeout near 40ms, was ${response.rawResponse.elapsedTime}ms",
+                )
+                assertTrue(
+                    response.rawResponse.elapsedTime < 250,
+                    "expected explicit timeout below 250ms, was ${response.rawResponse.elapsedTime}ms",
+                )
             }
         }
 }

--- a/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
@@ -98,6 +99,72 @@ class ObdDeviceConnectionTest {
         }
 
     @Test
+    fun `returns promptly when first byte arrives after a short delay`() =
+        runBlocking {
+            val input = ScriptedInputStream()
+            val output =
+                ScriptedOutputStream(
+                    input = input,
+                    responses =
+                        mapOf(
+                            "01 0D" to ResponsePlan(payload = "410D40>", autoEnqueue = false),
+                        ),
+                )
+            val connection = ObdDeviceConnection(input, output, Dispatchers.Default)
+            val command = TestObdCommand(tag = "SPEED", pid = "0D")
+
+            launch {
+                waitUntilWriteCount(output, 1)
+                delay(20)
+                input.enqueue("410D40>")
+            }
+
+            val response =
+                connection.runWithReadPolicy(
+                    command,
+                    readPolicy = ObdReadPolicy(responseTimeoutMs = 1_500, interByteTimeoutMs = 25),
+                )
+
+            assertEquals("410D40", response.value)
+            assertTrue(response.rawResponse.elapsedTime < 250, "expected elapsed time below 250ms, was ${response.rawResponse.elapsedTime}ms")
+        }
+
+    @Test
+    fun `keeps reading fragmented responses while bytes continue arriving`() =
+        runBlocking {
+            val input = ScriptedInputStream()
+            val output =
+                ScriptedOutputStream(
+                    input = input,
+                    responses =
+                        mapOf(
+                            "01 0C" to ResponsePlan(payload = "410C1AF8>", autoEnqueue = false),
+                        ),
+                )
+            val connection = ObdDeviceConnection(input, output, Dispatchers.Default)
+            val command = TestObdCommand(tag = "RPM", pid = "0C")
+
+            launch {
+                waitUntilWriteCount(output, 1)
+                delay(20)
+                input.enqueue("41")
+                delay(15)
+                input.enqueue("0C")
+                delay(15)
+                input.enqueue("1AF8>")
+            }
+
+            val response =
+                connection.runWithReadPolicy(
+                    command,
+                    readPolicy = ObdReadPolicy(responseTimeoutMs = 1_500, interByteTimeoutMs = 30),
+                )
+
+            assertEquals("410C1AF8", response.value)
+            assertEquals("410C1AF8", response.rawResponse.value)
+        }
+
+    @Test
     fun `propagates cancellation while waiting for data`() {
         runBlocking {
             val input = IdleInputStream()
@@ -116,16 +183,34 @@ class ObdDeviceConnectionTest {
     }
 
     @Test
-    fun `returns quickly when max retries is zero and no data is available`() =
+    fun `uses legacy max retries as response timeout budget`() =
         runBlocking {
             val input = IdleInputStream()
             val output = ByteArrayOutputStream()
             val connection = ObdDeviceConnection(input, output, Dispatchers.Default)
             val command = TestObdCommand(tag = "SPEED", pid = "0D")
 
-            withTimeout(400) {
-                val response = connection.run(command, maxRetries = 0)
+            withTimeout(1_500) {
+                val response = connection.run(command, maxRetries = 1)
                 assertEquals("", response.value)
+                assertTrue(response.rawResponse.elapsedTime >= 450, "expected at least ~500ms, was ${response.rawResponse.elapsedTime}ms")
+                assertTrue(response.rawResponse.elapsedTime < 1_200, "expected legacy timeout below 1200ms, was ${response.rawResponse.elapsedTime}ms")
+            }
+        }
+
+    @Test
+    fun `uses explicit read policy timeout when no data is available`() =
+        runBlocking {
+            val input = IdleInputStream()
+            val output = ByteArrayOutputStream()
+            val connection = ObdDeviceConnection(input, output, Dispatchers.Default)
+            val command = TestObdCommand(tag = "SPEED", pid = "0D")
+
+            withTimeout(500) {
+                val response = connection.runWithReadPolicy(command, readPolicy = ObdReadPolicy(responseTimeoutMs = 40, interByteTimeoutMs = 25))
+                assertEquals("", response.value)
+                assertTrue(response.rawResponse.elapsedTime >= 30, "expected explicit timeout near 40ms, was ${response.rawResponse.elapsedTime}ms")
+                assertTrue(response.rawResponse.elapsedTime < 250, "expected explicit timeout below 250ms, was ${response.rawResponse.elapsedTime}ms")
             }
         }
 }
@@ -211,4 +296,15 @@ private class IdleInputStream : InputStream() {
     override fun available(): Int = 0
 
     override fun read(): Int = -1
+}
+
+private suspend fun waitUntilWriteCount(
+    output: ScriptedOutputStream,
+    expectedCount: Int,
+) {
+    withTimeout(1_000) {
+        while (output.writes.size < expectedCount) {
+            delay(10)
+        }
+    }
 }

--- a/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
@@ -160,7 +160,7 @@ class ObdDeviceConnectionTest {
             val response =
                 connection.runWithReadPolicy(
                     command,
-                    readPolicy = ObdReadPolicy(responseTimeoutMs = 1_500, interByteTimeoutMs = 30),
+                    readPolicy = ObdReadPolicy(responseTimeoutMs = 1_500, interByteTimeoutMs = 150),
                 )
 
             assertEquals("410C1AF8", response.value)
@@ -184,6 +184,24 @@ class ObdDeviceConnectionTest {
             }
         }
     }
+
+    @Test
+    fun `returns quickly when max retries is zero and no data is available`() =
+        runBlocking {
+            val input = IdleInputStream()
+            val output = ByteArrayOutputStream()
+            val connection = ObdDeviceConnection(input, output, Dispatchers.Default)
+            val command = TestObdCommand(tag = "SPEED", pid = "0D")
+
+            withTimeout(400) {
+                val response = connection.run(command, maxRetries = 0)
+                assertEquals("", response.value)
+                assertTrue(
+                    response.rawResponse.elapsedTime < 200,
+                    "expected near-immediate return, was ${response.rawResponse.elapsedTime}ms",
+                )
+            }
+        }
 
     @Test
     fun `uses legacy max retries as response timeout budget`() =

--- a/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/connection/ObdDeviceConnectionTest.kt
@@ -168,6 +168,38 @@ class ObdDeviceConnectionTest {
         }
 
     @Test
+    fun `uses the legacy retry budget between response fragments`() =
+        runBlocking {
+            val input = ScriptedInputStream()
+            val output =
+                ScriptedOutputStream(
+                    input = input,
+                    responses =
+                        mapOf(
+                            "01 0C" to ResponsePlan(payload = "410C1AF8>", autoEnqueue = false),
+                        ),
+                )
+            val connection = ObdDeviceConnection(input, output, Dispatchers.Default)
+            val command = TestObdCommand(tag = "RPM", pid = "0C")
+
+            launch {
+                waitUntilWriteCount(output, 1)
+                delay(20)
+                input.enqueue("SEARCHING\r")
+                delay(700)
+                input.enqueue("410C1AF8>")
+            }
+
+            val response =
+                withTimeout(2_500) {
+                    connection.run(command, maxRetries = 3)
+                }
+
+            assertEquals("410C1AF8", response.value)
+            assertEquals("410C1AF8", response.rawResponse.value)
+        }
+
+    @Test
     fun `propagates cancellation while waiting for data`() {
         runBlocking {
             val input = IdleInputStream()


### PR DESCRIPTION
## Summary

This change improves how `ObdDeviceConnection` reads adapter responses and fixes a couple of AT command serialization issues.

## What changed

- replaced the fixed 500ms retry sleep in `ObdDeviceConnection` with a lower-latency timeout-driven polling loop
- preserved the public `run(command, useCache, delayTime, maxRetries)` API
- kept the new timing policy internal so there is no public API expansion in this change
- improved fragmented-response handling by resetting the idle window after successful reads
- normalized AT adaptive timing command serialization
- normalized AT timeout command formatting to uppercase, zero-padded hex
- added focused tests for:
  - short first-byte delays
  - fragmented responses
  - legacy timeout compatibility
  - AT command serialization
- updated docs with the current timeout behavior and a recommended low-noise ELM327 setup sequence

## Compatibility

- no public API signature changes
- `maxRetries` is still supported and now maps to the updated internal timeout behavior
- command execution remains serialized per connection
- caching behavior is unchanged

## Why

The previous read loop used a fixed 500ms wait when no bytes were immediately available, which made response handling slower than necessary and less robust for fragmented adapter output.

This change keeps the existing API intact while making response reads more responsive and predictable.
