### PR TITLE
fix: only parse 2 data bytes for RPM responses

### DIFF
--- a/src/main/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
+++ b/src/main/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
@@ -32,7 +32,9 @@ class RPMCommand : ObdCommand() {
     override val pid = "0C"
 
     override val defaultUnit = "RPM"
-    override val handler = { response: ObdRawResponse -> (bytesToInt(response.bufferedValue) / RPM_DIVISOR).toString() }
+    override val handler = { response: ObdRawResponse ->
+        (bytesToInt(response.bufferedValue, bytesToProcess = 2) / RPM_DIVISOR).toString()
+    }
 }
 
 class MassAirFlowCommand : ObdCommand() {

--- a/src/test/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
+++ b/src/test/kotlin/com/github/eltonvs/obd/command/engine/Engine.kt
@@ -46,6 +46,13 @@ class RPMCommandParameterizedTests(
         fun values() =
             listOf(
                 arrayOf<Any>("410C200D", 2051),
+                arrayOf<Any>("410C10A4", 1065),
+                arrayOf<Any>("41 0C 10 A4", 1065),
+                arrayOf<Any>("41 0c 10 a4", 1065),
+                arrayOf<Any>("410C10A4410C10C1", 1065),
+                arrayOf<Any>("41 0C 10 A4 41 0C 10 C1", 1065),
+                arrayOf<Any>("410C0E02410C0E02", 896),
+                arrayOf<Any>("41 0C 0E 02  41 0C 0E 02", 896),
                 arrayOf<Any>("410C283C", 2575),
                 arrayOf<Any>("410C0A00", 640),
                 arrayOf<Any>("410C0000", 0),


### PR DESCRIPTION
## Summary
- limit RPM parsing to the two data bytes returned by PID 0C
- add regression coverage for concatenated RPM frames and input formatting variants

## Why
The RPM handler was parsing every buffered byte after the response header. If multiple RPM frames were present in the raw response, trailing bytes could change the computed result.
