### PR TITLE
ci: harden GitHub Actions supply chain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,25 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
+    name: verify
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: "25"
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
       - name: Verify
         run: ./gradlew --no-daemon clean test ktlintCheck detekt

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip
+distributionSha256Sum=17f277867f6914d61b1aa02efab1ba7bb439ad652ca485cd8ca6842fccec6e43
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What changed

- pin every GitHub Action to an immutable full commit SHA
- disable checkout credential persistence
- grant the workflow only read access to repository contents
- cancel superseded CI runs while preserving the required `verify` check name
- verify the Gradle 9.3.1 distribution with its published SHA-256 checksum

## Why

A maximal zizmor audit found mutable action references, implicit workflow permissions, persisted checkout credentials, and missing concurrency controls. These changes remove those findings and reduce CI supply-chain risk.

Repository-level Actions permissions were also tightened separately to allow only GitHub-owned actions and `gradle/actions/*`, default workflow tokens to read-only, disable workflow PR approvals, and require `verify` against the latest base branch.

## Impact

CI behavior is unchanged apart from canceling superseded runs. Action and Gradle distribution updates now require intentional checksum or SHA updates.

## Validation

- `zizmor --persona=auditor --no-ignores --collect=all --strict-collection .` — no findings
- `./gradlew --no-daemon clean test ktlintCheck detekt` — successful
- 313 tests passed
- `git diff --check` — clean
